### PR TITLE
Fixed #14 for 1.19.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.daemon=false
 java_version=17
 
 mod_id=simpleshops
-mod_version=1.2.2
+mod_version=1.2.3
 
 minecraft_version=1.19.2
 forge_version=43.2.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.daemon=false
 java_version=17
 
 mod_id=simpleshops
-mod_version=1.2.3
+mod_version=1.2.2
 
 minecraft_version=1.19.2
 forge_version=43.2.4

--- a/src/main/java/wolforce/simpleshops/SimpleShopTileEntity.java
+++ b/src/main/java/wolforce/simpleshops/SimpleShopTileEntity.java
@@ -186,7 +186,15 @@ public class SimpleShopTileEntity extends BlockEntityParent {
 	}
 	
 	public void spawn(Level world, Vec3 pos, ItemStack stack, int amount) {
-		spawn(world, pos, Util.setCount(stack, amount));
+		int maxStackSize = stack.getMaxStackSize();
+		int fullStacks = amount / maxStackSize;
+		for(int i = 0; i < fullStacks; i++){
+			spawn(world, pos, Util.setCount(stack, maxStackSize));
+		}
+		int remainder = amount % maxStackSize;
+		if(remainder > 0){
+			spawn(world, pos, Util.setCount(stack, remainder));
+		}
 	}
 	
 	public void spawn(Level world, Vec3 pos, ItemStack stack) {


### PR DESCRIPTION
Reworked drop spawning logic to split the stack up as needed based on the item's max stack size